### PR TITLE
Save whether wide-mode is enabled or not

### DIFF
--- a/frontend/.env
+++ b/frontend/.env
@@ -2,3 +2,4 @@ VITE_MY_WEBSITE_NAME=AVolle
 VITE_MY_WEBSITE_URL=https://avolle.com?s=lm-log
 VITE_GITHUB_URL=https://github.com/mentisy/logicmachine-log
 VITE_GITHUB_ISSUES_URL=https://github.com/mentisy/logicmachine-log/issues
+VITE_STORAGE_PREFIX=log

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,10 +2,10 @@ import "./App.css";
 import { BugAntIcon } from "@heroicons/react/24/outline";
 import MainContent from "./components/MainContent.tsx";
 import Footer from "./components/Footer.tsx";
-import { useState } from "react";
+import useLocalStorage from "./hooks/useLocalStorage.ts";
 
 export default function App() {
-    const [wideMode, setWideMode] = useState(false);
+    const [wideMode, setWideMode] = useLocalStorage("widemode", false);
     let narrowClass = "";
     if (!wideMode) {
         narrowClass = " lg:w-4/5 max-w-screen-lg";

--- a/frontend/src/hooks/useLocalStorage.ts
+++ b/frontend/src/hooks/useLocalStorage.ts
@@ -1,0 +1,23 @@
+import { useEffect, useState } from "react";
+
+export default function useLocalStorage(key: string, defaultValue?: any) {
+    const keyWithPrefix = `${import.meta.env.VITE_STORAGE_PREFIX}_${key}`;
+    const [localValue, setLocalValue] = useState<any | undefined>();
+
+    useEffect(() => {
+        const value = localStorage.getItem(keyWithPrefix);
+        if (value === undefined && defaultValue) {
+            setLocalValue(defaultValue);
+        } else if (value) {
+            setLocalValue(JSON.parse(value));
+        }
+    });
+
+    const changeValue = (value: any) => {
+        const newValue = JSON.stringify(value);
+        localStorage.setItem(keyWithPrefix, newValue);
+        setLocalValue(newValue);
+    };
+
+    return [localValue, changeValue];
+}


### PR DESCRIPTION
In the app you can enable wide mode to show a wider table on larger screens. This PR adds a feature that saves the wide mode setting, so whenever you open the app, it remembers how you left it.